### PR TITLE
Allow multiple command line arguments

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	if len(os.Args) == 2 {
+	if len(os.Args) >= 2 {
 		applyToArgs()
 	} else {
 		applyToStdin()
@@ -26,5 +26,12 @@ func applyToStdin() {
 }
 
 func applyToArgs() {
-	fmt.Println(spongecase.ApplyStr(os.Args[1]))
+	for i, arg := range os.Args[1:] {
+		str := spongecase.ApplyStr(arg)
+		if i < len(os.Args) - 2 {
+			str += " "
+		}
+		fmt.Print(str)
+	}
+	fmt.Println()
 }


### PR DESCRIPTION
This adds the ability to supply more than one command line argument. This can be quite handy if you don't want to use quotation marks.