### PR TITLE
Produce different/random results for each call

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,14 @@ package main
 import (
 	"fmt"
 	"github.com/FabianTe/spongecase"
+	"math/rand"
+	"time"
 )
 
 func main() {
+	rand.Seed(time.Now().UTC().UnixNano())
 	fmt.Println(spongecase.ApplyStr("This will definitely build my reputation as a software developer"))
 }
 ```
+
+*Hint: if you want different/random results (similar to the behavior of the command line version), you need to set a seed with `rand.Seed` first (as shown in the example).*

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,10 +4,13 @@ import (
 	"bufio"
 	"fmt"
 	"github.com/FabianTe/spongecase"
+	"math/rand"
 	"os"
+	"time"
 )
 
 func main() {
+	rand.Seed(time.Now().UTC().UnixNano())
 	if len(os.Args) >= 2 {
 		applyToArgs()
 	} else {


### PR DESCRIPTION
I'm not sure if it was an intentional decision to not set a seed when starting the command line interface.
However, the sequence of uppercase and lowercase letters is always the same with the current implementation (instead of being actually random). Setting the current time as the seed for the random number generator should help avoiding that.